### PR TITLE
Point main merge sonarcloud to only ./src

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,4 +48,5 @@ jobs:
           args: >
             -Dsonar.organization=bcgov-sonarcloud
             -Dsonar.projectKey=${{ github.event.repository.name }}
+            -Dsonar.sources=src
           # -Dsonar.verbose=true


### PR DESCRIPTION
Adding Java projects under .apis/ threw off SonarCloud.  This points the scans just to ./src, which is the default TS/JS app.