### PR TITLE
deps/minimist

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -103,6 +103,11 @@
             "strip-ansi": "^6.0.0",
             "through": "^2.3.6"
           }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         }
       }
     },
@@ -5447,9 +5452,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "@nestjs/platform-express": "^8.4.2",
     "@nestjs/schematics": "^8.0.8",
     "@nestjs/testing": "^8.4.2",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.4"
   },


### PR DESCRIPTION
Updated to 1.2.6

One outstanding:
```
├─┬ @nestjs/cli@8.2.4
│ ├─┬ @angular-devkit/schematics-cli@13.3.0
│ │ └── minimist@1.2.5 
```

Dependabot:
```
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).
```
https://github.com/bcgov/greenfield-template/security/dependabot/5