### PR TITLE
Reenable Trivy, point at frontend and backend

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -180,7 +180,12 @@ jobs:
         image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-backend
         format: table
         exit-code: '1'
-        severity: HIGH
+        severity: CRITICAL
+
+    - name: Upload Trivy results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: 'trivy-results.sarif'
 
   trivy-frontend:
     name: Trivy-Frontend
@@ -199,8 +204,12 @@ jobs:
         image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-frontend
         format: table
         exit-code: '1'
-        severity: HIGH
+        severity: CRITICAL
 
+    - name: Upload Trivy results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: 'trivy-results.sarif'
 
   deploy:
     name: Deploy

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -162,6 +162,7 @@ jobs:
       with:
         args: --all-projects --severity-threshold=high
 
+  # https://github.com/marketplace/actions/aqua-security-trivy
   trivy-backend:
     name: Trivy-Backend
     needs:
@@ -179,9 +180,7 @@ jobs:
         image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-backend
         format: table
         exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: os,library
-        severity: CRITICAL
+        severity: HIGH
 
   trivy-frontend:
     name: Trivy-Frontend
@@ -200,9 +199,7 @@ jobs:
         image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-frontend
         format: table
         exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: os,library
-        severity: CRITICAL
+        severity: HIGH
 
 
   deploy:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -218,7 +218,7 @@ jobs:
         sarif_file: 'trivy-results.sarif'
 
   trivy-image-frontend:
-    name: trivy-image-frontend
+    name: Trivy-Image-Frontend
     needs:
       - build
       - codeql
@@ -295,8 +295,6 @@ jobs:
     name: Zap
     needs:
       - deploy
-      - trivy-image-backend
-      - trivy-image-frontend
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -195,6 +195,7 @@ jobs:
       - snyk
       - tests-frontend
       - tests-backend
+      - trivy-repo
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -224,6 +225,7 @@ jobs:
       - snyk
       - tests-frontend
       - tests-backend
+      - trivy-repo
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -253,6 +255,7 @@ jobs:
       - snyk
       - tests-frontend
       - tests-backend
+      - trivy-repo
     runs-on: ubuntu-latest
     environment:
       name: dev

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -162,6 +162,43 @@ jobs:
       with:
         args: --all-projects --severity-threshold=high
 
+  trivy-backend:
+    name: Trivy Backend
+    needs:
+      - build
+    if: needs.check.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Trivy Vulnerability Scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-backend
+        format: table
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: os,library
+        severity: CRITICAL
+
+  trivy-frontend:
+    name: Trivy Frontend
+    needs:
+      - build
+    if: needs.check.outputs.build == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - name: Trivy Vulnerability Scan
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-frontend
+        format: table
+        exit-code: '1'
+        ignore-unfixed: true
+        vuln-type: os,library
+        severity: CRITICAL
+
+
   deploy:
     name: Deploy
     needs: 
@@ -222,21 +259,3 @@ jobs:
           cmd_options: '-a'
           allow_issue_writing: false
           fail_action: false
-
-  # trivy:
-  #   name: Trivy
-  #   needs:
-  #     - build
-  #   if: needs.check.outputs.build == 'true'
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   steps:
-  #   - name: Trivy Vulnerability Scan
-  #     uses: aquasecurity/trivy-action@master
-  #     with:
-  #       image-ref: ghcr.io/bcgov/greenfield-template:pr-${{ github.event.number }}
-  #       format: table
-  #       exit-code: '1'
-  #       ignore-unfixed: true
-  #       vuln-type: os,library
-  #       severity: CRITICAL

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -174,6 +174,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
     - name: Trivy Vulnerability Scan
       uses: aquasecurity/trivy-action@master
       with:
@@ -200,6 +203,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
     - name: Trivy Vulnerability Scan
       uses: aquasecurity/trivy-action@master
       with:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -163,8 +163,32 @@ jobs:
         args: --all-projects --severity-threshold=high
 
   # https://github.com/marketplace/actions/aqua-security-trivy
-  trivy-backend:
-    name: Trivy-Backend
+  trivy-repo:
+    name: Trivy-Repo
+    needs:
+      - check
+    if: needs.check.outputs.build == 'true'
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  trivy-image-backend:
+    name: Trivy-Image-Backend
     needs:
       - build
       - codeql

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -170,9 +170,8 @@ jobs:
       - snyk
       - tests-frontend
       - tests-backend
-    if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
     - name: Trivy Vulnerability Scan
       uses: aquasecurity/trivy-action@master
@@ -192,9 +191,8 @@ jobs:
       - snyk
       - tests-frontend
       - tests-backend
-    if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
     - name: Trivy Vulnerability Scan
       uses: aquasecurity/trivy-action@master
@@ -215,7 +213,6 @@ jobs:
       - snyk
       - tests-frontend
       - tests-backend
-    if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     environment:
       name: dev
@@ -257,7 +254,6 @@ jobs:
       - deploy
       - trivy-backend
       - trivy-frontend
-    if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -163,9 +163,13 @@ jobs:
         args: --all-projects --severity-threshold=high
 
   trivy-backend:
-    name: Trivy Backend
+    name: Trivy-Backend
     needs:
       - build
+      - codeql
+      - snyk
+      - tests-frontend
+      - tests-backend
     if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -181,9 +185,13 @@ jobs:
         severity: CRITICAL
 
   trivy-frontend:
-    name: Trivy Frontend
+    name: Trivy-Frontend
     needs:
       - build
+      - codeql
+      - snyk
+      - tests-frontend
+      - tests-backend
     if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -203,6 +211,8 @@ jobs:
     name: Deploy
     needs: 
       - build
+      - codeql
+      - snyk
       - tests-frontend
       - tests-backend
     if: needs.check.outputs.build == 'true'
@@ -244,8 +254,9 @@ jobs:
   zap:
     name: Zap
     needs:
-      - check
       - deploy
+      - trivy-backend
+      - trivy-frontend
     if: needs.check.outputs.build == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -216,8 +216,8 @@ jobs:
       with:
         sarif_file: 'trivy-results.sarif'
 
-  trivy-frontend:
-    name: Trivy-Frontend
+  trivy-image-frontend:
+    name: trivy-image-frontend
     needs:
       - build
       - codeql
@@ -292,8 +292,8 @@ jobs:
     name: Zap
     needs:
       - deploy
-      - trivy-backend
-      - trivy-frontend
+      - trivy-image-backend
+      - trivy-image-frontend
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -178,9 +178,11 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-backend
-        format: table
         exit-code: '1'
+        ignore-unfixed: true
         severity: CRITICAL
+        format: 'sarif'
+        output: 'trivy-results.sarif'
 
     - name: Upload Trivy results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v1
@@ -202,9 +204,11 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         image-ref: ghcr.io/bcgov/greenfield-template:${{ github.event.number }}-frontend
-        format: table
         exit-code: '1'
+        ignore-unfixed: true
         severity: CRITICAL
+        format: 'sarif'
+        output: 'trivy-results.sarif'
 
     - name: Upload Trivy results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v1


### PR DESCRIPTION
Image and repo scanner.  Has previously been a pain, but should be revisited.