### PR TITLE
Improve image handling and promotion

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -347,7 +347,7 @@ jobs:
         if: steps.check.outputs.build == 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           target: ${{ github.event.number }}-${{ env.COMPONENT }}
           tags: |
@@ -406,7 +406,7 @@ jobs:
         if: steps.check.outputs.build == 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           target: ${{ github.event.number }}-${{ env.COMPONENT }}
           tags: |
@@ -454,7 +454,7 @@ jobs:
       - name: Promote Backend Image to PROD
         uses: shrink/actions-docker-registry-tag@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           target: ${{ env.PREV }}-backend
           tags: |
@@ -463,7 +463,7 @@ jobs:
       - name: Promote Frontend Image to PROD
         uses: shrink/actions-docker-registry-tag@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           target: ${{ env.PREV }}-frontend
           tags: |

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -241,7 +241,7 @@ jobs:
           oc project ${{ secrets.OC_NAMESPACE }}
 
           # Do not replace database; 'oc create' kicks up an error if objects already exist
-          oc process -f .github/openshift/deploy.database.yml -p ZONE=${{ env.ZONE }} | oc apply -f - || true
+          oc process -f .github/openshift/deploy.database.yml -p ZONE=${{ env.ZONE }} | oc create -f - || true
 
           # Process and apply deployment templates
           oc process -f .github/openshift/deploy.backend.yml -p ZONE=${{ env.ZONE }} \
@@ -294,11 +294,129 @@ jobs:
           allow_issue_writing: false
           fail_action: false
 
-  deploy-prod:
-    name: PROD Deployment
+  image-backend:
+    name: Backend Image Handling
     needs:
       - zap-backend
       - zap-frontend
+    outputs:
+      build: ${{ steps.check.outputs.build }}
+    env:
+      COMPONENT: backend
+      PREV: test
+      ZONE: prod
+    environment:
+      name: prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for image changes
+        id: check
+        run: |
+          # Vars
+          IMG_PREV="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
+          IMG_ZONE="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
+
+          # Pull previous image; grab SHA
+          docker pull "${IMG_PREV}"
+          SHA_PREV=$(docker inspect -f '{{.Id}}' "${IMG_PREV}")
+
+          # Use blank SHA for promoted image, unless a real one exists instead
+          docker pull "${IMG_ZONE}" && \
+            SHA_ZONE=$(docker inspect -f '{{.Id}}' "${IMG_ZONE}") ||
+            SHA_ZONE=""
+
+          # Output SHAs
+          echo -e "\n${IMG_PREV}: ${SHA_PREV}"
+          echo -e "${IMG_ZONE}: ${SHA_ZONE}\n"
+
+          # If different, then trigger updates
+          if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
+            echo "::set-output name=build::true"
+            echo "Image has changed"
+
+            # Login to OpenShift and select project
+            oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
+            oc project ${{ secrets.OC_NAMESPACE }}
+
+            oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
+            exit 0
+          fi
+          echo "Image promotion not required"
+
+      - name: Promote Backend Image
+        if: steps.check.outputs.build == 'true'
+        uses: shrink/actions-docker-registry-tag@v2
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository }}
+          target: ${{ github.event.number }}-${{ env.COMPONENT }}
+          tags: |
+            ${{ env.PROMOTION }}-${{ env.COMPONENT }}
+
+  image-frontend:
+    name: Frontend Image Handling
+    needs:
+      - zap-backend
+      - zap-frontend
+    outputs:
+      build: ${{ steps.check.outputs.build }}
+    env:
+      COMPONENT: frontend
+      PREV: test
+      ZONE: prod
+    environment:
+      name: prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for image changes
+        id: check
+        run: |
+          # Vars
+          IMG_PREV="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
+          IMG_ZONE="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
+
+          # Pull previous image; grab SHA
+          docker pull "${IMG_PREV}"
+          SHA_PREV=$(docker inspect -f '{{.Id}}' "${IMG_PREV}")
+
+          # Use blank SHA for promoted image, unless a real one exists instead
+          docker pull "${IMG_ZONE}" && \
+            SHA_ZONE=$(docker inspect -f '{{.Id}}' "${IMG_ZONE}") ||
+            SHA_ZONE=""
+
+          # Output SHAs
+          echo -e "\n${IMG_PREV}: ${SHA_PREV}"
+          echo -e "${IMG_ZONE}: ${SHA_ZONE}\n"
+
+          # If different, then trigger updates
+          if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
+            echo "::set-output name=build::true"
+            echo "Image has changed"
+
+            # Login to OpenShift and select project
+            oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
+            oc project ${{ secrets.OC_NAMESPACE }}
+
+            oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
+            exit 0
+          fi
+          echo "Image promotion not required"
+
+      - name: Promote Backend Image
+        if: steps.check.outputs.build == 'true'
+        uses: shrink/actions-docker-registry-tag@v2
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository }}
+          target: ${{ github.event.number }}-${{ env.COMPONENT }}
+          tags: |
+            ${{ env.PROMOTION }}-${{ env.COMPONENT }}
+
+  deploy-prod:
+    name: PROD Deployment
+    needs:
+      - image-backend
+      - image-frontend
     runs-on: ubuntu-latest
     environment:
       name: prod
@@ -313,12 +431,8 @@ jobs:
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
           oc project ${{ secrets.OC_NAMESPACE }}
 
-          # Clear previous images
-          oc delete is ${{ env.NAME }}-${{ env.ZONE }}-backend || true
-          oc delete is ${{ env.NAME }}-${{ env.ZONE }}-frontend || true
-
           # Do not replace database; 'oc create' kicks up an error if objects already exist
-          oc process -f .github/openshift/deploy.database.yml -p ZONE=${{ env.ZONE }} | oc apply -f - || true
+          oc process -f .github/openshift/deploy.database.yml -p ZONE=${{ env.ZONE }} | oc create -f - || true
 
           # Process and apply deployment templates
           oc process -f .github/openshift/deploy.backend.yml -p ZONE=${{ env.ZONE }} \

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -240,10 +240,6 @@ jobs:
           oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
           oc project ${{ secrets.OC_NAMESPACE }}
 
-          # Clear previous images
-          oc delete is ${{ env.NAME }}-${{ env.ZONE }}-backend || true
-          oc delete is ${{ env.NAME }}-${{ env.ZONE }}-frontend || true
-
           # Do not replace database; 'oc create' kicks up an error if objects already exist
           oc process -f .github/openshift/deploy.database.yml -p ZONE=${{ env.ZONE }} | oc apply -f - || true
 

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -49,28 +49,28 @@ jobs:
         id: check
         run: |
           # Vars
-          IMG_OLD="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
-          IMG_NEW="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
+          IMG_PREV="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
+          IMG_ZONE="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
 
           # Make sure an image exists to promote; grab SHA
-          if [[ ! $(docker pull "${IMG_OLD}") ]]; then
+          if [[ ! $(docker pull "${IMG_PREV}") ]]; then
               echo -e "\n No images to promote"
               exit 0
           fi
-          SHA_OLD=$(docker inspect -f '{{.Id}}' "${IMG_OLD}")
+          SHA_PREV=$(docker inspect -f '{{.Id}}' "${IMG_PREV}")
 
           # Use blank SHA for promoted image, unless a real one exists instead
-          SHA_NEW=""
-          if [[ $(docker pull "${IMG_NEW}") ]]; then
-            SHA_NEW=$(docker inspect -f '{{.Id}}' "${IMG_NEW}")
+          SHA_ZONE=""
+          if [[ $(docker pull "${IMG_ZONE}") ]]; then
+            SHA_ZONE=$(docker inspect -f '{{.Id}}' "${IMG_ZONE}")
           fi
 
           # Output SHAs
-          echo -e "\n${IMG_OLD}: ${SHA_OLD}"
-          echo -e "${IMG_NEW}: ${SHA_NEW}\n"
+          echo -e "\n${IMG_PREV}: ${SHA_PREV}"
+          echo -e "${IMG_ZONE}: ${SHA_ZONE}\n"
 
           # If different, then trigger updates
-          if [[ "${SHA_OLD}" != "${SHA_NEW}" ]]; then
+          if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
             echo "::set-output name=build::true"
             echo "Image has changed"
 
@@ -111,28 +111,28 @@ jobs:
         id: check
         run: |
           # Vars
-          IMG_OLD="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
-          IMG_NEW="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
+          IMG_PREV="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
+          IMG_ZONE="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
 
           # Make sure an image exists to promote; grab SHA
-          if [[ ! $(docker pull "${IMG_OLD}") ]]; then
+          if [[ ! $(docker pull "${IMG_PREV}") ]]; then
               echo -e "\n No images to promote"
               exit 0
           fi
-          SHA_OLD=$(docker inspect -f '{{.Id}}' "${IMG_OLD}")
+          SHA_PREV=$(docker inspect -f '{{.Id}}' "${IMG_PREV}")
 
           # Use blank SHA for promoted image, unless a real one exists instead
-          SHA_NEW=""
-          if [[ $(docker pull "${IMG_NEW}") ]]; then
-            SHA_NEW=$(docker inspect -f '{{.Id}}' "${IMG_NEW}")
+          SHA_ZONE=""
+          if [[ $(docker pull "${IMG_ZONE}") ]]; then
+            SHA_ZONE=$(docker inspect -f '{{.Id}}' "${IMG_ZONE}")
           fi
 
           # Output SHAs
-          echo -e "\n${IMG_OLD}: ${SHA_OLD}"
-          echo -e "${IMG_NEW}: ${SHA_NEW}\n"
+          echo -e "\n${IMG_PREV}: ${SHA_PREV}"
+          echo -e "${IMG_ZONE}: ${SHA_ZONE}\n"
 
           # If different, then trigger updates
-          if [[ "${SHA_OLD}" != "${SHA_NEW}" ]]; then
+          if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
             echo "::set-output name=build::true"
             echo "Image has changed"
 

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -87,7 +87,7 @@ jobs:
         if: steps.check.outputs.build == 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           target: ${{ github.event.number }}-${{ env.COMPONENT }}
           tags: |
@@ -149,7 +149,7 @@ jobs:
         if: steps.check.outputs.build == 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           repository: ${{ github.repository }}
           target: ${{ github.event.number }}-${{ env.COMPONENT }}
           tags: |

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -38,32 +38,47 @@ jobs:
       build: ${{ steps.check.outputs.build }}
     env:
       COMPONENT: backend
-      PROMOTION: test
+      PREV: ${{ github.event.number }}
+      ZONE: test
     environment:
       name: test
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
-      - name: Check and process modified files
+      - name: Check for image changes
         id: check
         run: |
-          set -eux
+          # Vars
+          IMG_OLD="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
+          IMG_NEW="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
 
-          # Pull images and SHAs
-          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }}
-          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }}
-          SHA0=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }})
-          SHA1=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }})
+          # Make sure an image exists to promote; grab SHA
+          if [[ ! $(docker pull "${IMG_OLD}") ]]; then
+              echo -e "\n No images to promote"
+              exit 0
+          fi
+          SHA_OLD=$(docker inspect -f '{{.Id}}' "${IMG_OLD}")
+
+          # Use blank SHA for promoted image, unless a real one exists instead
+          SHA_NEW=""
+          if [[ $(docker pull "${IMG_NEW}") ]]; then
+            SHA_NEW=$(docker inspect -f '{{.Id}}' "${IMG_NEW}")
+          fi
+
+          # Output SHAs
+          echo -e "\n${IMG_OLD}: ${SHA_OLD}"
+          echo -e "${IMG_NEW}: ${SHA_NEW}\n"
 
           # If different, then trigger updates
-          if [[ "${SHA0}" == "${SHA1} "]]; then
+          if [[ "${SHA_OLD}" != "${SHA_NEW}" ]]; then
             echo "::set-output name=build::true"
             echo "Image has changed"
 
             # Login to OpenShift and select project
             oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
             oc project ${{ secrets.OC_NAMESPACE }}
-            oc delete is/${{ env.NAME }}-${{ env.PROMOTION}}-${{ env.COMPONENT }} || true
+
+            oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
             exit 0
           fi
           echo "Image promotion not required"
@@ -85,32 +100,47 @@ jobs:
       build: ${{ steps.check.outputs.build }}
     env:
       COMPONENT: frontend
-      PROMOTION: test
+      PREV: ${{ github.event.number }}
+      ZONE: test
     environment:
       name: test
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
-      - name: Check and process modified files
+      - name: Check for image changes
         id: check
         run: |
-          set -eux
+          # Vars
+          IMG_OLD="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PREV }}-${{ env.COMPONENT }}"
+          IMG_NEW="${{ env.REGISTRY }}/${{ github.repository }}:${{ env.ZONE }}-${{ env.COMPONENT }}"
 
-          # Pull images and SHAs
-          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }}
-          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }}
-          SHA0=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }})
-          SHA1=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }})
+          # Make sure an image exists to promote; grab SHA
+          if [[ ! $(docker pull "${IMG_OLD}") ]]; then
+              echo -e "\n No images to promote"
+              exit 0
+          fi
+          SHA_OLD=$(docker inspect -f '{{.Id}}' "${IMG_OLD}")
+
+          # Use blank SHA for promoted image, unless a real one exists instead
+          SHA_NEW=""
+          if [[ $(docker pull "${IMG_NEW}") ]]; then
+            SHA_NEW=$(docker inspect -f '{{.Id}}' "${IMG_NEW}")
+          fi
+
+          # Output SHAs
+          echo -e "\n${IMG_OLD}: ${SHA_OLD}"
+          echo -e "${IMG_NEW}: ${SHA_NEW}\n"
 
           # If different, then trigger updates
-          if [[ "${SHA0}" == "${SHA1} "]]; then
+          if [[ "${SHA_OLD}" != "${SHA_NEW}" ]]; then
             echo "::set-output name=build::true"
             echo "Image has changed"
 
             # Login to OpenShift and select project
             oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
             oc project ${{ secrets.OC_NAMESPACE }}
-            oc delete is/${{ env.NAME }}-${{ env.PROMOTION}}-${{ env.COMPONENT }} || true
+
+            oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
             exit 0
           fi
           echo "Image promotion not required"

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -11,6 +11,7 @@ on:
       - "**.yaml"
 
 env:
+  REGISTRY: ghcr.io
   NAME: gfp
 
 jobs:
@@ -30,29 +31,99 @@ jobs:
           # Remove old build runs, build pods and deployment pods
           oc delete all,pvc,secret -l app=${{ env.NAME }}-${{ github.event.number }}
 
-  # Promote images when PR merged and branch = main
-  promote-images:
-    name: Promote DEV images to TEST
+  # If merged, then handle any image promotion
+  image-backend:
+    name: Backend Image Handling
+    outputs:
+      build: ${{ steps.check.outputs.build }}
+    env:
+      COMPONENT: backend
+      PROMOTION: test
+    environment:
+      name: test
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:
-      - name: Promote Backend Image to TEST
-        uses: shrink/actions-docker-registry-tag@v2
-        with:
-          registry: ghcr.io
-          repository: ${{ github.repository }}
-          target: ${{ github.event.number }}-backend
-          tags: |
-            test-backend
+      - name: Check and process modified files
+        id: check
+        run: |
+          set -eux
 
-      - name: Promote Frontend Image to TEST
+          # Pull images and SHAs
+          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }}
+          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }}
+          SHA0=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }})
+          SHA1=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }})
+
+          # If different, then trigger updates
+          if [[ "${SHA0}" == "${SHA1} "]]; then
+            echo "::set-output name=build::true"
+            echo "Image has changed"
+
+            # Login to OpenShift and select project
+            oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
+            oc project ${{ secrets.OC_NAMESPACE }}
+            oc delete is/${{ env.NAME }}-${{ env.PROMOTION}}-${{ env.COMPONENT }} || true
+            exit 0
+          fi
+          echo "Image promotion not required"
+
+      - name: Promote Backend Image
+        if: steps.check.outputs.build == 'true'
         uses: shrink/actions-docker-registry-tag@v2
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}
-          target: ${{ github.event.number }}-frontend
+          target: ${{ github.event.number }}-${{ env.COMPONENT }}
           tags: |
-            test-frontend
+            ${{ env.PROMOTION }}-${{ env.COMPONENT }}
+
+  # If merged, then handle any image promotion
+  image-frontend:
+    name: Frontend Image Handling
+    outputs:
+      build: ${{ steps.check.outputs.build }}
+    env:
+      COMPONENT: frontend
+      PROMOTION: test
+    environment:
+      name: test
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    steps:
+      - name: Check and process modified files
+        id: check
+        run: |
+          set -eux
+
+          # Pull images and SHAs
+          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }}
+          docker pull ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }}
+          SHA0=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.number }}-${{ env.COMPONENT }})
+          SHA1=$(docker inspect -f '{{.Id}}' ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.PROMOTION }}-${{ env.COMPONENT }})
+
+          # If different, then trigger updates
+          if [[ "${SHA0}" == "${SHA1} "]]; then
+            echo "::set-output name=build::true"
+            echo "Image has changed"
+
+            # Login to OpenShift and select project
+            oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
+            oc project ${{ secrets.OC_NAMESPACE }}
+            oc delete is/${{ env.NAME }}-${{ env.PROMOTION}}-${{ env.COMPONENT }} || true
+            exit 0
+          fi
+          echo "Image promotion not required"
+
+      - name: Promote Backend Image
+        if: steps.check.outputs.build == 'true'
+        uses: shrink/actions-docker-registry-tag@v2
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository }}
+          target: ${{ github.event.number }}-${{ env.COMPONENT }}
+          tags: |
+            ${{ env.PROMOTION }}-${{ env.COMPONENT }}
 
   # Notify when PR merged and branch = main
   merge-notification:

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello Backend!"', () => {
-      expect(appController.getHello()).toBe('Hello Backend!');
+    it('should return "Hello Backend Modification #1!"', () => {
+      expect(appController.getHello()).toBe('Hello Backend Modification #1!');
     });
   });
 });

--- a/backend/src/app.service.ts
+++ b/backend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from "@nestjs/common";
 @Injectable()
 export class AppService {
   getHello(): string {
-    return "Hello Backend!";
+    return "Hello Backend Modification #1!";
   }
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,3 +17,5 @@ async function bootstrap() {
   await app.listen(3000);
 }
 bootstrap();
+
+// Trigger

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -17,5 +17,3 @@ async function bootstrap() {
   await app.listen(3000);
 }
 bootstrap();
-
-// Trigger

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello Backend!'))
+    .expect('Hello Backend Modification #1!'))
 })

--- a/frontend/src/app.controller.spec.ts
+++ b/frontend/src/app.controller.spec.ts
@@ -13,9 +13,9 @@ describe('AppController', () => {
   })
 
   describe('getHello', () => {
-    it('should return "Hello Frontend Modification!"', () => {
+    it('should return "Hello Frontend Modification #1!"', () => {
       const appController = app.get<AppController>(AppController)
-      expect(appController.getHello()).toBe('Hello Frontend Modification!')
+      expect(appController.getHello()).toBe('Hello Frontend Modification #1!')
     })
   })
 })

--- a/frontend/src/app.service.ts
+++ b/frontend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class AppService {
   getHello (): string {
-    return 'Hello Frontend Modification!'
+    return 'Hello Frontend Modification #1!'
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -6,5 +6,3 @@ async function bootstrap () {
   await app.listen(3000)
 }
 bootstrap()
-
-// Trigger

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,4 +7,4 @@ async function bootstrap () {
 }
 bootstrap()
 
-// Junk commit
+// Trigger

--- a/frontend/test/app.e2e-spec.ts
+++ b/frontend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello Frontend Modification!'))
+    .expect('Hello Frontend Modification #1!'))
 })


### PR DESCRIPTION
Stale images have been causing us to delete all images, creating much slower and less reliable rolling upgrades.  The issue appears to be between OpenShift and GHCR.io.