### PR TITLE
Reenable PROD deployment gate, prompt only once

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -394,6 +394,28 @@ jobs:
       ZONE: prod
       PREV: test
     steps:
+      - name: Remove any stale backend images
+        if: needs.image-backend.outputs.build != 'true'
+        env:
+          COMPONENT: backend
+        run: |
+          # Login to OpenShift and select project
+          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
+          oc project ${{ secrets.OC_NAMESPACE }}
+
+          oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
+
+      - name: Remove any stale frontend images
+        if: needs.image-frontend.outputs.build != 'true'
+        env:
+          COMPONENT: frontend
+        run: |
+          # Login to OpenShift and select project
+          oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
+          oc project ${{ secrets.OC_NAMESPACE }}
+
+          oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
+
       - uses: actions/checkout@v2
       - name: Deploy
         run: |

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -265,8 +265,6 @@ jobs:
       COMPONENT: backend
       PREV: test
       ZONE: prod
-    environment:
-      name: prod
     runs-on: ubuntu-latest
     steps:
       - name: Check for image changes
@@ -293,12 +291,6 @@ jobs:
           if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
             echo "::set-output name=build::true"
             echo "Image has changed"
-
-            # Login to OpenShift and select project
-            oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-            oc project ${{ secrets.OC_NAMESPACE }}
-
-            oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
             exit 0
           fi
           echo "Image promotion not required"
@@ -324,8 +316,6 @@ jobs:
       COMPONENT: frontend
       PREV: test
       ZONE: prod
-    environment:
-      name: prod
     runs-on: ubuntu-latest
     steps:
       - name: Check for image changes
@@ -352,12 +342,6 @@ jobs:
           if [[ "${SHA_PREV}" != "${SHA_ZONE}" ]]; then
             echo "::set-output name=build::true"
             echo "Image has changed"
-
-            # Login to OpenShift and select project
-            oc login --token=${{ secrets.OC_TOKEN }} --server=${{ secrets.OC_SERVER }}
-            oc project ${{ secrets.OC_NAMESPACE }}
-
-            oc delete is/${{ env.NAME }}-${{ env.ZONE}}-${{ env.COMPONENT }} || true
             exit 0
           fi
           echo "Image promotion not required"

--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -254,6 +254,31 @@ jobs:
           allow_issue_writing: false
           fail_action: false
 
+  # https://github.com/snyk/cli, https://github.com/snyk/actions
+  # Note: using free tier - called late in pipeline to limit runs
+  snyk:
+    name: Vulnerability Report
+    needs:
+      - zap-backend
+      - zap-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        continue-on-error: true # To make sure that SARIF upload gets called
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --all-projects --severity-threshold=high --sarif-file-output=snyk.sarif
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: snyk.sarif
+
   image-backend:
     name: Backend Image Handling
     needs:
@@ -355,31 +380,6 @@ jobs:
           target: ${{ env.PREV }}-${{ env.COMPONENT }}
           tags: |
             ${{ env.ZONE }}-${{ env.COMPONENT }}
-
-  # https://github.com/snyk/cli, https://github.com/snyk/actions
-  # Note: using free tier - called late in pipeline to limit runs
-  snyk:
-    name: Vulnerability Report
-    needs:
-      - zap-backend
-      - zap-frontend
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/node@master
-        continue-on-error: true # To make sure that SARIF upload gets called
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --all-projects --severity-threshold=high --sarif-file-output=snyk.sarif
-
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
 
   deploy-prod:
     name: PROD Deployment

--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -31,7 +31,7 @@ jobs:
 
   # If merged, then handle any image promotion
   image-backend:
-    name: Backend Image Handling
+    name: Backend Image Promotion
     outputs:
       build: ${{ steps.check.outputs.build }}
     env:
@@ -93,7 +93,7 @@ jobs:
 
   # If merged, then handle any image promotion
   image-frontend:
-    name: Frontend Image Handling
+    name: Frontend Image Promotion
     outputs:
       build: ${{ steps.check.outputs.build }}
     env:

--- a/frontend/src/app.controller.spec.ts
+++ b/frontend/src/app.controller.spec.ts
@@ -13,9 +13,9 @@ describe('AppController', () => {
   })
 
   describe('getHello', () => {
-    it('should return "Hello Frontend!"', () => {
+    it('should return "Hello Frontend!@"', () => {
       const appController = app.get<AppController>(AppController)
-      expect(appController.getHello()).toBe('Hello Frontend!')
+      expect(appController.getHello()).toBe('Hello Frontend!@')
     })
   })
 })

--- a/frontend/src/app.service.ts
+++ b/frontend/src/app.service.ts
@@ -3,6 +3,6 @@ import { Injectable } from '@nestjs/common'
 @Injectable()
 export class AppService {
   getHello (): string {
-    return 'Hello Frontend!'
+    return 'Hello Frontend!@'
   }
 }

--- a/frontend/test/app.e2e-spec.ts
+++ b/frontend/test/app.e2e-spec.ts
@@ -18,5 +18,5 @@ describe('AppController (e2e)', () => {
   it('/ (GET)', () => request(app.getHttpServer())
     .get('/')
     .expect(200)
-    .expect('Hello Frontend!'))
+    .expect('Hello Frontend!@'))
 })


### PR DESCRIPTION
There are multiple jobs using `environment.name: PROD`, which kicks up multiple review/deploy prompts.  Shuffle the logic to use only one prompt.